### PR TITLE
Fix server statistics data calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to the DCS Statistics Website Uploader project.
 
 ### 🐛 Bug Fixes & Improvements
 
+#### Server Statistics Data Calculation
+**What Changed:** Fixed server statistics to use correct event types from actual data structure
+**Why:** The dashboard was showing incorrect statistics due to mismatched event types and incorrect data field references.
+
+**Technical Fixes:**
+- Changed visit counting from S_EVENT_MISSION_START to S_EVENT_TAKEOFF (actual server activity)
+- Updated kill counting to use S_EVENT_HIT events instead of S_EVENT_KILL
+- Enhanced death tracking to include all death-related events:
+  - S_EVENT_CRASH
+  - S_EVENT_EJECTION
+  - S_EVENT_PILOT_DEAD
+  - S_EVENT_KILL (when target is an airplane)
+- Removed artificial fallback logic that was inflating visit counts
+
 #### Carrier Trap Tracking Fixes
 **What Changed:** Fixed carrier trap statistics showing 0 for pilots with actual traps
 **Why:** The system was looking for incorrect field names in traps.json, causing all trap counts to show as zero even for pilots with multiple carrier landings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ All notable changes to the DCS Statistics Website Uploader project.
   - S_EVENT_KILL (when target is an airplane)
 - Removed artificial fallback logic that was inflating visit counts
 
+#### Chart Alignment Fixes
+**What Changed:** Fixed left-aligned charts on dashboard and pilot statistics pages
+**Why:** Charts and content were aligned to the left side of the page instead of being properly centered, affecting the visual presentation.
+
+**Technical Fixes:**
+- Added proper centering to main element on both pages
+- Set max-width: 1400px for index.php to accommodate wider dashboard layout
+- Set max-width: 1200px for pilot_statistics.php for optimal readability
+- Maintains responsive design with proper centering on all screen sizes
+
 #### Carrier Trap Tracking Fixes
 **What Changed:** Fixed carrier trap statistics showing 0 for pilots with actual traps
 **Why:** The system was looking for incorrect field names in traps.json, causing all trap counts to show as zero even for pilots with multiple carrier landings.

--- a/dcs-stats/index.php
+++ b/dcs-stats/index.php
@@ -598,6 +598,12 @@ setInterval(loadServerStats, 30000);
 </script>
 
 <style>
+main {
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 2rem;
+}
+
 .dashboard-header {
     text-align: center;
     margin-bottom: 40px;

--- a/dcs-stats/pilot_statistics.php
+++ b/dcs-stats/pilot_statistics.php
@@ -697,6 +697,12 @@ document.getElementById('playerSearchInput').addEventListener('keypress', functi
 </script>
 
 <style>
+main {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem;
+}
+
 .pilot-card {
     background-color: #2c2c2c;
     border-radius: 12px;


### PR DESCRIPTION
## Summary
- Fixed server statistics to use correct event types based on actual data structure analysis
- Resolved incorrect visit, kill, and death counts on dashboard

## Changes
- **Visit Counting**: Changed from S_EVENT_MISSION_START to S_EVENT_TAKEOFF (actual server activity)
- **Kill Tracking**: Updated to use S_EVENT_HIT events instead of S_EVENT_KILL
- **Death Tracking**: Enhanced to include all death scenarios:
  - S_EVENT_CRASH
  - S_EVENT_EJECTION
  - S_EVENT_PILOT_DEAD
  - S_EVENT_KILL (when target is an airplane)
- **Removed**: Artificial fallback logic that was inflating visit counts

## Testing
- Analyzed sample data to understand correct event structure
- Verified event types match actual DCS server data format
- Confirmed statistics now accurately reflect player activity

## Impact
Dashboard will now show accurate:
- Total player visits (based on takeoffs)
- Server-wide kills (based on hits)
- Death counts (all death scenarios)
- Top 5 pilots by actual activity
- Top 3 squadrons by member visits