### PR TITLE
Hotfix: URL rewriting and footer hyperlinks

### DIFF
--- a/dcs-stats/.htaccess
+++ b/dcs-stats/.htaccess
@@ -23,9 +23,11 @@ RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^admin/([^/]+)/?$ admin/$1.php [L]
 
-# Redirect .php requests to clean URLs (optional - prevents duplicate content)
-RewriteCond %{THE_REQUEST} \s/+(.*?)\.php[\s?] [NC]
-RewriteRule ^(.*)\.php$ /$1 [R=301,L]
+# Comment out redirect rules - they cause issues with subdirectory installations
+# If you want to enforce clean URLs, uncomment these lines but be aware it may
+# cause issues when the site is installed in a subdirectory
+# RewriteCond %{THE_REQUEST} \s/+(.*?)\.php[\s?] [NC]
+# RewriteRule ^(.*)\.php$ /$1 [R=301,L]
 
 # Custom error pages (optional)
 ErrorDocument 404 /404.php

--- a/dcs-stats/admin/.htaccess
+++ b/dcs-stats/admin/.htaccess
@@ -1,5 +1,23 @@
 # Admin Panel Access Control
 
+# Enable Rewrite Engine for clean URLs
+<IfModule mod_rewrite.c>
+    RewriteEngine On
+    
+    # Remove .php extension from URLs
+    # If the request is for a file that exists, serve it
+    RewriteCond %{REQUEST_FILENAME} -f
+    RewriteRule ^(.*)$ - [L]
+    
+    # If the request is for a directory that exists, serve it
+    RewriteCond %{REQUEST_FILENAME} -d
+    RewriteRule ^(.*)$ - [L]
+    
+    # If the request doesn't have .php extension and the .php file exists, rewrite to it
+    RewriteCond %{REQUEST_FILENAME}.php -f
+    RewriteRule ^([^/]+)/?$ $1.php [L]
+</IfModule>
+
 # Protect sensitive directories
 <FilesMatch "\.(json|sql|log)$">
     Order deny,allow

--- a/dcs-stats/footer.php
+++ b/dcs-stats/footer.php
@@ -1,5 +1,5 @@
 <footer>
-  <p>&copy; 2025 DCS Stats | Powered by SkyPirates & {503rd} Blacksheep</p>
+  <p>&copy; 2025 DCS Stats | Powered by <a href="https://skypirates.uk" target="_blank">SkyPirates</a> & <a href="https://503rdblacksheep.com" target="_blank">{503rd} Blacksheep</a></p>
 </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Fix admin panel clean URLs returning 404 errors
- Fix redirect issues for subdirectory installations  
- Add hyperlinks to SkyPirates and 503rd Blacksheep in footer

## Changes
1. **Admin .htaccess URL rewriting**
   - Added mod_rewrite rules to handle clean URLs in admin panel
   - Fixes 404 errors when accessing admin pages without .php extension

2. **Root .htaccess redirect fix**
   - Commented out problematic 301 redirect rules
   - Prevents redirect loops in subdirectory installations
   - Clean URLs still work via internal rewrites

3. **Footer hyperlinks**
   - SkyPirates links to https://skypirates.uk
   - 503rd Blacksheep links to https://503rdblacksheep.com
   - Links open in new tab

## Test plan
- [x] Admin panel URLs work without .php extension
- [x] No redirect loops in subdirectory installations
- [x] Footer links are clickable and open correct sites

🤖 Generated with Claude Code